### PR TITLE
Adding Yatta to install options

### DIFF
--- a/src/main/_data/docs.yml
+++ b/src/main/_data/docs.yml
@@ -15,6 +15,7 @@
   - setup-getting-started
   - setup-getting-started-saas-cloud
   - setup-bitnami
+  - setup-yatta
   - setup-configuration
   - setup-managing
   - setup-cli

--- a/src/main/_docs/setup/setup-getting-started.md
+++ b/src/main/_docs/setup/setup-getting-started.md
@@ -8,6 +8,8 @@ permalink: /:categories/getting-started/
 {% include base.html %}
 Eclipse Che is a developer workspace server and cloud IDE. You install, run, and manage Eclipse Che with Docker.
 
+The recommended way to install Che is on a machine with Docker 1.11+ by typing: `docker run eclipse/che start`. Alternatively, you can use the [Yatta profile]() - this is especially helpful for users who use Yatta for their Eclipse desktop IDE.
+
 ### Download
 This is the administration guide for the on-premises installation of Eclipse Che. This document discusses the installation, configuration, and operation of Che that you host on your own hardware or IaaS provider.
 

--- a/src/main/_docs/setup/setup-yatta.md
+++ b/src/main/_docs/setup/setup-yatta.md
@@ -1,0 +1,10 @@
+---
+tags: [ "eclipse" , "che" ]
+title: Getting Started&#58 Yatta
+excerpt: ""
+layout: docs
+permalink: /:categories/getting-started/
+---
+{% include base.html %}
+
+You can install Eclipse Che with a Yatta profile - this is especially convenient if you're using Yatta for your Eclipse desktop IDE as well.


### PR DESCRIPTION
This re-adds the Yatta installer instructions to the docs. There were lost in the transition from readme.io to GH for docs.