### PR TITLE
Use of workspace.runtime.docker.image instead of workspace.runtime.image.location

### DIFF
--- a/src/main/_docs/chedir-portable-workspaces/chedir-chefiles.md
+++ b/src/main/_docs/chedir-portable-workspaces/chedir-chefiles.md
@@ -45,7 +45,7 @@ workspace.name = “happy”
 
 # Define the Docker image to use to power the workspace's runtime
 # This must conform to: https://eclipse-che.readme.io/docs/recipes
-workspace.runtime.image.location="eclispe/alpine_jdk8"
+workspace.runtime.docker.image="eclispe/alpine_jdk8"
 
 # You can - instead - define the runtime using a Dockerfile in a git repo
 workspace.runtime.docker.location= "http://gist...../my-dockerfile"


### PR DESCRIPTION

Fix for https://github.com/eclipse/che/issues/3317
The documentation was not reflecting the spec/implementation.
The underlying type being "dockerimage" it is a element of workspace.runtime.docker.*