### PR TITLE
Add networking requirements to getting started

### DIFF
--- a/src/main/_docs/setup/setup-cli.md
+++ b/src/main/_docs/setup/setup-cli.md
@@ -59,6 +59,8 @@ GLOBAL COMMAND OPTIONS:
 
 The CLI will hide most error conditions from standard out. Internal stack traces and error output is redirected to `cli.log`, which is saved in the host folder where `:/data` is mounted.
 
+You can override any value in `che.env` for a single execution by passing in `-e NAME=VALUE` on the command line. The CLI will detect the values on the command line and ignore those imported from `che.env`.
+
 ### action
 Executes some actions on the Eclipse Che instance or on a workspace running inside Che.
 For example to list all workspaces on Che, the following command can be used `action list-workspaces`.

--- a/src/main/_docs/setup/setup-getting-started.md
+++ b/src/main/_docs/setup/setup-getting-started.md
@@ -140,6 +140,7 @@ Che goes through a progression algorithm to establish the protocol, IP address a
 
 1. Failed Che -> Workspace (set CHE_DOCKER_IP in `che.env`)
 2. Failed Browser -> Workspace (set CHE_DOCKER_IP_EXTERNAL in `che.env`)
+3. Firewall (required ports are not open)
 
 When you first install Che, we will add a `che.env` file into the folder you mounted to `:/data`, and you can configure many variables to establish proper communications. After changing this file, restart Che for the changes to take affect.
 


### PR DESCRIPTION
I have updated the content of `che.env` and also the netwokring pre-reqs in our docs. I think it's important that everyone sees these materials as these are the most common errors that prevent successful startup.  Will add matching one for Codenvy.