### PR TITLE
Fix md error for screenshot in Preview

### DIFF
--- a/src/main/_docs/use-che-as-an-ide/ide-previews.md
+++ b/src/main/_docs/use-che-as-an-ide/ide-previews.md
@@ -15,4 +15,4 @@ Preview objects are stored as part of command. {{ site.product_mini_name }} will
 
 The preview object will dynamically determine the appropriate URL when the command is run.
 
-![Capture_preview.PNG]({{base}}{{site.links["Capture_preview.PNG"]}}
+![Capture_preview.PNG]({{base}}{{site.links["Capture_preview.PNG"]}})


### PR DESCRIPTION
This fixes the broken image at the bottom of https://eclipse.org/che/docs/ide/previews/index.html
