### PR TITLE
Removed duplicated word

### DIFF
--- a/src/main/_docs/setup/setup-bitnami.md
+++ b/src/main/_docs/setup/setup-bitnami.md
@@ -7,7 +7,7 @@ permalink: /:categories/bitnami/
 ---
 {% include base.html %}
 
-Bitnami provides provides a [one-click install](https://bitnami.com/stack/eclipse-che) solution for deploying Eclipse Che to your own cloud account.
+Bitnami provides a [one-click install](https://bitnami.com/stack/eclipse-che) solution for deploying Eclipse Che to your own cloud account.
 
 # 1. Install Che  
 Bitnami will automatically install Che to your cloud account, just select your provider and then choose "Add Account" from the menu:


### PR DESCRIPTION
As pointed out in [this PR](https://github.com/eclipse/che-docs/pull/171) there was a duplicated word in the intro of the Bitnami setup docs. As the author of that PR hasn't signed an Eclipse CLA I'm removing the word myself.

Signed-off-by: Brad Micklea <bmicklea@codenvy.com>