### PR TITLE
Che minimal and standard assembly documentation

### DIFF
--- a/src/main/_docs/assemblies/assemblies-assembly-lifecycle.md
+++ b/src/main/_docs/assemblies/assemblies-assembly-lifecycle.md
@@ -231,9 +231,14 @@ The `archetype generate` command will generate two custom assemblies: one for Ec
 The Eclipse Che and Codenvy CLI have (mostly) identical syntax, so you can build and run either custom assembly. By default, the `archetype build` and `archetype run` commands default to the Che custom assembly.  You can switch to the Codenvy assembly by appending `--codenvy` to either command.
 
 # Customizing
-Our archetypes generate a functional custom assembly with some pre-built customizations. You can further customize an assembly by either a) excluding plugins or assets from Che / Codenvy, b) including new plugins or assets that you have created, or c) both. For example, if you want to replace Che's git plugin with an improvement that you make, you would both exclude the default one provided by Che and then include a new plugin that you author.
+Our archetypes generate a functional custom assembly with some pre-built customizations. You can further customize an assembly by:
+- Excluding plugins or assets from Che / Codenvy
+- Including new plugins or assets that you have created
+- Both
 
-After you exclude / include new plugins, you just perform another build to package the assembly with the updated plugin list.
+For example, if you want to replace Che's git plugin with an improvement that you make, you would both exclude the default one provided by Che and then include a new plugin that you author.
+
+After you exclude / include new plugins, perform another build to package the assembly with the updated plugin list.
 
 #### Standard Assemblies
 There are five different places where you can include or exclude a plugin, which are items we call "standard assemblies". The "standard assemblies" generate packages that will be run as an asset in a different location. Che and Codenvy are distributed systems, so there are components that run in a browser, on the server, and within a workspace. Each one of these components are independently packaged into a "standard assembly".
@@ -301,7 +306,6 @@ You can have as many `<exclusion>` blocks as necessary within a single `<exclusi
 
 We require the maven POM to be sorted. If you get a sorting error, you can sort your modifications on the command line with `mvn sortpom:sort`.
 
-
 #### Include
 You include your plugin by modifying the same assembly `pom.xml` and add a new `<dependency>` block:
 ```
@@ -312,6 +316,129 @@ You include your plugin by modifying the same assembly `pom.xml` and add a new `
 ```
 
 We require the maven POM to be sorted. If you get a sorting error, you can sort your modifications on the command line with `mvn sortpom:sort`.
+
+### Minimal and Standard Assemblies
+There are two ways to build an assembly
+1. As a minimal framework into which you can add plugins.
+2. As a standard assembly with all included default plugins.
+
+There are two maven modules that you will need to consider:
+- ```che-ide-core```: The core components of the IDE.
+- ```che-wsagent-core```: The core components of the Che server.
+
+#### How to use them
+These two modules will be used to create either an assembly or samples.
+
+#### Standard IDE Assembly
+To make a standard assembly of the IDE, we need to declare it in `assembly/assembly-ide-war/pom.xml`.
+
+1. Standard IDE core only
+
+```
+   <dependency>
+      <groupId>org.eclipse.che.core</groupId>
+      <artifactId>che-ide-core</artifactId>
+   </dependency>
+```
+
+2.  Standard IDE core plus all Che IDE plugins
+
+```
+   <dependency>
+      <groupId>org.eclipse.che.plugin</groupId>
+      <artifactId>*</artifactId>
+   </dependency>
+```
+
+#### Minimal IDE Assembly
+To make a minimal assembly of the IDE, we need to declare it in `assembly/assembly-ide-war/pom.xml`.
+
+1. Minimal IDE core only
+
+```
+   <dependency>
+      <groupId>org.eclipse.che.core</groupId>
+      <artifactId>che-ide-core</artifactId>
+   </dependency>
+```
+
+2.  Minimal IDE core plus all Che IDE plugins
+
+```
+   <dependency>
+      <groupId>my.plugin</groupId>
+      <artifactId>plugin-json-ide</artifactId>
+   </dependency>
+```
+
+3.  Minimal IDE WAR that will be reused to get some resources
+
+```
+   <dependency>
+      <groupId>org.eclipse.che</groupId>
+      <artifactId>assembly-ide-war</artifactId>
+      <type>war</type>
+      <scope>runtime</scope>
+   </dependency>
+```
+
+#### Full Assembly of ws-agent Server WAR
+
+1. Core ws-agent WAR
+
+```
+   <dependency>
+      <groupId>org.eclipse.che.core</groupId>
+      <artifactId>che-wsagent-core</artifactId>
+      <type>war</type>
+   </dependency>
+```
+
+2. Swagger support
+
+```
+   <dependency>
+      <groupId>org.eclipse.che.lib</groupId>
+      <artifactId>che-swagger-module</artifactId>
+   </dependency>
+```
+
+3. All ws-agent plugins
+
+```
+   <dependency>
+      <groupId>org.eclipse.che.plugin</groupId>
+      <artifactId>che-plugin-*</artifactId>
+   </dependency>
+```
+
+#### Custom assembly of minimal Che ws-agent
+
+1. Core ws-agent war
+```
+    <dependency>
+      <groupId>org.eclipse.che.core</groupId>
+      <artifactId>che-wsagent-core</artifactId>
+      <type>war</type>
+   </dependency>
+```
+
+2. Server side plugins
+```
+   <dependency>
+      <groupId>my.plugin</groupId>
+      <artifactId>plugin-json-server</artifactId>
+   </dependency>
+```
+
+#### Size Differences for Minimal and Standard Assemblies
+
+| Value  | Minimal  |  Standard |
+|---|---|---|
+| ws-agent WAR size    |   17MB | 34 MB  |
+| GWT compilation  |   4min  |  6min |
+| GWT scripts size  |  4.5 MB |   7.7 MB |
+| IDE WAR size  |   6.3MB |   8MB |      
 
 # IDE
 You can use your own IDE for developing plugins that are deployed within Che. We use Eclipse, Che and IntelliJ internally to create Che itself. You can [create a similar development environment and workflow](https://github.com/eclipse/che/wiki/Development-Workflow#ide-setup) for customizations that you make.

--- a/src/main/_docs/assemblies/assemblies-assembly-lifecycle.md
+++ b/src/main/_docs/assemblies/assemblies-assembly-lifecycle.md
@@ -317,129 +317,6 @@ You include your plugin by modifying the same assembly `pom.xml` and add a new `
 
 We require the maven POM to be sorted. If you get a sorting error, you can sort your modifications on the command line with `mvn sortpom:sort`.
 
-### Minimal and Standard Assemblies
-There are two ways to build an assembly
-1. As a minimal framework into which you can add plugins.
-2. As a standard assembly with all included default plugins.
-
-There are two maven modules that you will need to consider:
-- ```che-ide-core```: The core components of the IDE.
-- ```che-wsagent-core```: The core components of the Che server.
-
-#### How to use them
-These two modules will be used to create either an assembly or samples.
-
-#### Standard IDE Assembly
-To make a standard assembly of the IDE, we need to declare it in `assembly/assembly-ide-war/pom.xml`.
-
-1. Standard IDE core only
-
-```
-   <dependency>
-      <groupId>org.eclipse.che.core</groupId>
-      <artifactId>che-ide-core</artifactId>
-   </dependency>
-```
-
-2.  Standard IDE core plus all Che IDE plugins
-
-```
-   <dependency>
-      <groupId>org.eclipse.che.plugin</groupId>
-      <artifactId>*</artifactId>
-   </dependency>
-```
-
-#### Minimal IDE Assembly
-To make a minimal assembly of the IDE, we need to declare it in `assembly/assembly-ide-war/pom.xml`.
-
-1. Minimal IDE core only
-
-```
-   <dependency>
-      <groupId>org.eclipse.che.core</groupId>
-      <artifactId>che-ide-core</artifactId>
-   </dependency>
-```
-
-2.  Minimal IDE core plus all Che IDE plugins
-
-```
-   <dependency>
-      <groupId>my.plugin</groupId>
-      <artifactId>plugin-json-ide</artifactId>
-   </dependency>
-```
-
-3.  Minimal IDE WAR that will be reused to get some resources
-
-```
-   <dependency>
-      <groupId>org.eclipse.che</groupId>
-      <artifactId>assembly-ide-war</artifactId>
-      <type>war</type>
-      <scope>runtime</scope>
-   </dependency>
-```
-
-#### Full Assembly of ws-agent Server WAR
-
-1. Core ws-agent WAR
-
-```
-   <dependency>
-      <groupId>org.eclipse.che.core</groupId>
-      <artifactId>che-wsagent-core</artifactId>
-      <type>war</type>
-   </dependency>
-```
-
-2. Swagger support
-
-```
-   <dependency>
-      <groupId>org.eclipse.che.lib</groupId>
-      <artifactId>che-swagger-module</artifactId>
-   </dependency>
-```
-
-3. All ws-agent plugins
-
-```
-   <dependency>
-      <groupId>org.eclipse.che.plugin</groupId>
-      <artifactId>che-plugin-*</artifactId>
-   </dependency>
-```
-
-#### Custom assembly of minimal Che ws-agent
-
-1. Core ws-agent war
-```
-    <dependency>
-      <groupId>org.eclipse.che.core</groupId>
-      <artifactId>che-wsagent-core</artifactId>
-      <type>war</type>
-   </dependency>
-```
-
-2. Server side plugins
-```
-   <dependency>
-      <groupId>my.plugin</groupId>
-      <artifactId>plugin-json-server</artifactId>
-   </dependency>
-```
-
-#### Size Differences for Minimal and Standard Assemblies
-
-| Value  | Minimal  |  Standard |
-|---|---|---|
-| ws-agent WAR size    |   17MB | 34 MB  |
-| GWT compilation  |   4min  |  6min |
-| GWT scripts size  |  4.5 MB |   7.7 MB |
-| IDE WAR size  |   6.3MB |   8MB |      
-
 # IDE
 You can use your own IDE for developing plugins that are deployed within Che. We use Eclipse, Che and IntelliJ internally to create Che itself. You can [create a similar development environment and workflow](https://github.com/eclipse/che/wiki/Development-Workflow#ide-setup) for customizations that you make.
 
@@ -473,6 +350,130 @@ Your custom assembly inherits from a base platform from Eclipse Che or Codenvy. 
 ```
 
 You can then rebuild your assembly normally. The parent reference will trigger Maven to download the new dependency libraries that relate to that particular version.
+
+# Creating Assemblies
+
+## Minimal and Standard Assemblies
+There are two ways to build an assembly
+1. As a minimal framework into which you can add plugins.
+2. As a standard assembly with all included default plugins.
+
+There are two maven modules that you will need to consider:
+- ```che-ide-core```: The core components of the IDE.
+- ```che-wsagent-core```: The core components of the Che server.
+
+These two modules will be used to create either a standard assembly or a sample.
+
+### Standard IDE Assembly
+To make a standard assembly of the IDE, we need to declare it in `assembly/assembly-ide-war/pom.xml`.
+
+1. Standard IDE core only
+
+```
+   <dependency>
+      <groupId>org.eclipse.che.core</groupId>
+      <artifactId>che-ide-core</artifactId>
+   </dependency>
+```
+
+2.  Standard IDE core plus all Che IDE plugins
+
+```
+   <dependency>
+      <groupId>org.eclipse.che.plugin</groupId>
+      <artifactId>*</artifactId>
+   </dependency>
+```
+
+### Minimal IDE Assembly
+To make a minimal assembly of the IDE, we need to declare it in `assembly/assembly-ide-war/pom.xml`.
+
+1. Minimal IDE core only
+
+```
+   <dependency>
+      <groupId>org.eclipse.che.core</groupId>
+      <artifactId>che-ide-core</artifactId>
+   </dependency>
+```
+
+2.  Minimal IDE core plus all Che IDE plugins
+
+```
+   <dependency>
+      <groupId>my.plugin</groupId>
+      <artifactId>plugin-json-ide</artifactId>
+   </dependency>
+```
+
+3.  Minimal IDE WAR that will be reused to get some resources
+
+```
+   <dependency>
+      <groupId>org.eclipse.che</groupId>
+      <artifactId>assembly-ide-war</artifactId>
+      <type>war</type>
+      <scope>runtime</scope>
+   </dependency>
+```
+
+### Full Assembly of ws-agent Server WAR
+
+1. Core ws-agent WAR
+
+```
+   <dependency>
+      <groupId>org.eclipse.che.core</groupId>
+      <artifactId>che-wsagent-core</artifactId>
+      <type>war</type>
+   </dependency>
+```
+
+2. Swagger support
+
+```
+   <dependency>
+      <groupId>org.eclipse.che.lib</groupId>
+      <artifactId>che-swagger-module</artifactId>
+   </dependency>
+```
+
+3. All ws-agent plugins
+
+```
+   <dependency>
+      <groupId>org.eclipse.che.plugin</groupId>
+      <artifactId>che-plugin-*</artifactId>
+   </dependency>
+```
+
+### Custom assembly of minimal Che ws-agent
+
+1. Core ws-agent war
+```
+    <dependency>
+      <groupId>org.eclipse.che.core</groupId>
+      <artifactId>che-wsagent-core</artifactId>
+      <type>war</type>
+   </dependency>
+```
+
+2. Server side plugins
+```
+   <dependency>
+      <groupId>my.plugin</groupId>
+      <artifactId>plugin-json-server</artifactId>
+   </dependency>
+```
+
+### Size Differences for Minimal and Standard Assemblies
+
+| Value  | Minimal  |  Standard |
+|---|---|---|
+| ws-agent WAR size    |   17MB | 34 MB  |
+| GWT compilation  |   4min  |  6min |
+| GWT scripts size  |  4.5 MB |   7.7 MB |
+| IDE WAR size  |   6.3MB |   8MB |      
 
 # Production Mode
 TODO: Discuss how to take a custom assembly that is ready for deployment and then package it within a custom Docker image to replace `eclipse/che-server` with a new image that contains a custom assembly's binaries.

--- a/src/main/_docs/assemblies/assemblies-assembly-lifecycle.md
+++ b/src/main/_docs/assemblies/assemblies-assembly-lifecycle.md
@@ -358,9 +358,11 @@ There are two ways to build an assembly
 1. As a minimal framework into which you can add plugins.
 2. As a standard assembly with all included default plugins.
 
+{% if site.product_mini_cli=="che" %}
+
 There are two maven modules that you will need to consider:
 - ```che-ide-core```: The core components of the IDE.
-- ```che-wsagent-core```: The core components of the Che server.
+- ```che-wsagent-core```: The core components of the server-side workspace agent.
 
 These two modules will be used to create either a standard assembly or a sample.
 
@@ -417,7 +419,7 @@ To make a minimal assembly of the IDE, we need to declare it in `assembly/assemb
    </dependency>
 ```
 
-### Full Assembly of ws-agent Server WAR
+### Standard Assembly of ws-agent Server WAR
 
 1. Core ws-agent WAR
 
@@ -447,7 +449,7 @@ To make a minimal assembly of the IDE, we need to declare it in `assembly/assemb
    </dependency>
 ```
 
-### Custom assembly of minimal Che ws-agent
+### Custom Assembly of Minimal Che ws-agent
 
 1. Core ws-agent war
 ```
@@ -474,6 +476,156 @@ To make a minimal assembly of the IDE, we need to declare it in `assembly/assemb
 | GWT compilation  |   4min  |  6min |
 | GWT scripts size  |  4.5 MB |   7.7 MB |
 | IDE WAR size  |   6.3MB |   8MB |      
+
+{% endif %}
+
+{% if site.product_mini_cli=="codenvy" %}
+
+There are two maven modules that you will need to consider:
+- ```codenvy-ide-core```: The core components of the IDE.
+- ```codenvy-wsagent-core```: The core components of the server-side workspace agent.
+
+These two modules will be used to create either a standard assembly or a sample.
+
+### Standard IDE Assembly
+To make a standard assembly of the IDE, we need to declare it in `assembly/compiling-ide-war/pom.xml`.
+
+1. Standard IDE core only
+
+```
+   <dependency>
+      <groupId>org.eclipse.che.core</groupId>
+      <artifactId>che-ide-core</artifactId>
+   </dependency>
+```
+
+2.  All IDE plugins we have in Codenvy.
+
+```
+   <dependency>
+      <groupId>com.codenvy.plugin</groupId>
+      <artifactId>codenvy-plugin-*</artifactId>
+   </dependency>
+```
+
+3.  All IDE plugins we have in Che.
+
+```
+   <dependency>
+      <groupId>org.eclipse.che</groupId>
+      <artifactId>assembly-ide-war</artifactId>
+      <classifier>classes</classifier>
+      <exclusions>
+         <exclusion>
+            <artifactId>che-plugin-product-info</artifactId>
+            <groupId>org.eclipse.che.plugin</groupId>
+         </exclusion>
+      </exclusions>
+   </dependency>
+```
+
+### Minimal IDE Assembly
+To make a minimal assembly of the IDE, we need to declare it in `assembly/assembly-ide-war/pom.xml`.
+
+1. Codenvy IDE Core
+
+```
+   <dependency>
+      <groupId>com.codenvy.onpremises</groupId>
+      <artifactId>codenvy-ide-core</artifactId>
+      <scope>provided</scope>
+   </dependency>
+```
+
+2.  IDE Part of a Custom Plugin
+
+```
+   <dependency>
+      <groupId>my.plugin</groupId>
+      <artifactId>plugin-json-ide</artifactId>
+      <scope>provided</scope>
+   </dependency>
+```
+
+3.  IDE WAR is Reused to Get Key Resources
+
+```
+   <dependency>
+      <groupId>com.codenvy.onpremises</groupId>
+      <artifactId>assembly-ide-war</artifactId>
+      <type>war</type>
+      <scope>runtime</scope>
+   </dependency>
+```
+
+### Standard Assembly of ws-agent Server WAR
+
+1. Core ws-agent WAR
+
+```
+   <dependency>
+      <groupId>com.codenvy.onpremises.wsagent</groupId>
+      <artifactId>codenvy-wsagent-core</artifactId>
+      <type>war</type>
+   </dependency>
+```
+
+2.  Swagger Support
+
+```
+   <dependency>
+      <groupId>org.eclipse.che.lib</groupId>
+      <artifactId>che-swagger-module</artifactId>
+   </dependency>
+```
+
+3. All Codenvy ws-agent Plugins
+
+```
+   <dependency>
+      <groupId>com.codenvy.plugin</groupId>
+      <artifactId>codenvy-plugin-*</artifactId>
+   </dependency>
+```
+
+4. All Che ws-agent Plugins
+
+```
+   <dependency>
+      <groupId>org.eclipse.che</groupId>
+      <artifactId>assembly-wsagent-war</artifactId>
+      <classifier>classes</classifier>
+      <exclusions>
+         <exclusion>
+            <artifactId>che-wsagent-core</artifactId>
+            <groupId>org.eclipse.che.core</groupId>
+         </exclusion>
+      </exclusions>
+   </dependency>
+```
+
+### Custom Assembly of Minimal Codenvy ws-agent
+
+1. Core Ws Agent WAR
+
+```
+   <dependency>
+      <groupId>com.codenvy.onpremises.wsagent</groupId>
+      <artifactId>codenvy-wsagent-core</artifactId>
+      <type>war</type>
+   </dependency>
+```
+
+2. Server Side Plugin
+
+```
+   <dependency>
+      <groupId>my.plugin</groupId>
+      <artifactId>plugin-json-server</artifactId>
+   </dependency>
+```
+
+{% endif %}
 
 # Production Mode
 TODO: Discuss how to take a custom assembly that is ready for deployment and then package it within a custom Docker image to replace `eclipse/che-server` with a new image that contains a custom assembly's binaries.

--- a/src/main/_docs/assemblies/assemblies-assembly-lifecycle.md
+++ b/src/main/_docs/assemblies/assemblies-assembly-lifecycle.md
@@ -353,7 +353,6 @@ You can then rebuild your assembly normally. The parent reference will trigger M
 
 # Creating Assemblies
 
-## Minimal and Standard Assemblies
 There are two ways to build an assembly
 1. As a minimal framework into which you can add plugins.
 2. As a standard assembly with all included default plugins.
@@ -366,10 +365,10 @@ There are two maven modules that you will need to consider:
 
 These two modules will be used to create either a standard assembly or a sample.
 
-### Standard IDE Assembly
+## Standard IDE Assembly
 To make a standard assembly of the IDE, we need to declare it in `assembly/assembly-ide-war/pom.xml`.
 
-1. Standard IDE core only
+**1) Standard IDE core only**
 
 ```
    <dependency>
@@ -378,7 +377,7 @@ To make a standard assembly of the IDE, we need to declare it in `assembly/assem
    </dependency>
 ```
 
-2.  Standard IDE core plus all Che IDE plugins
+**2) Standard IDE core plus all Che IDE plugins**
 
 ```
    <dependency>
@@ -387,10 +386,10 @@ To make a standard assembly of the IDE, we need to declare it in `assembly/assem
    </dependency>
 ```
 
-### Minimal IDE Assembly
+## Minimal IDE Assembly
 To make a minimal assembly of the IDE, we need to declare it in `assembly/assembly-ide-war/pom.xml`.
 
-1. Minimal IDE core only
+**1) Minimal IDE core only**
 
 ```
    <dependency>
@@ -399,7 +398,7 @@ To make a minimal assembly of the IDE, we need to declare it in `assembly/assemb
    </dependency>
 ```
 
-2.  Minimal IDE core plus all Che IDE plugins
+**2) Minimal IDE core plus all Che IDE plugins**
 
 ```
    <dependency>
@@ -408,7 +407,7 @@ To make a minimal assembly of the IDE, we need to declare it in `assembly/assemb
    </dependency>
 ```
 
-3.  Minimal IDE WAR that will be reused to get some resources
+**3) Minimal IDE WAR that will be reused to get some resources**
 
 ```
    <dependency>
@@ -419,9 +418,9 @@ To make a minimal assembly of the IDE, we need to declare it in `assembly/assemb
    </dependency>
 ```
 
-### Standard Assembly of ws-agent Server WAR
+## Standard Assembly of ws-agent Server WAR
 
-1. Core ws-agent WAR
+**1) Core ws-agent WAR**
 
 ```
    <dependency>
@@ -431,7 +430,7 @@ To make a minimal assembly of the IDE, we need to declare it in `assembly/assemb
    </dependency>
 ```
 
-2. Swagger support
+**2) Swagger support**
 
 ```
    <dependency>
@@ -440,7 +439,7 @@ To make a minimal assembly of the IDE, we need to declare it in `assembly/assemb
    </dependency>
 ```
 
-3. All ws-agent plugins
+**3) All ws-agent plugins**
 
 ```
    <dependency>
@@ -449,9 +448,10 @@ To make a minimal assembly of the IDE, we need to declare it in `assembly/assemb
    </dependency>
 ```
 
-### Custom Assembly of Minimal Che ws-agent
+## Custom Assembly of Minimal Che ws-agent
 
-1. Core ws-agent war
+**1) Core ws-agent war**
+
 ```
     <dependency>
       <groupId>org.eclipse.che.core</groupId>
@@ -460,22 +460,14 @@ To make a minimal assembly of the IDE, we need to declare it in `assembly/assemb
    </dependency>
 ```
 
-2. Server side plugins
+**2) Server side plugins**
+
 ```
    <dependency>
       <groupId>my.plugin</groupId>
       <artifactId>plugin-json-server</artifactId>
    </dependency>
 ```
-
-### Size Differences for Minimal and Standard Assemblies
-
-| Value  | Minimal  |  Standard |
-|---|---|---|
-| ws-agent WAR size    |   17MB | 34 MB  |
-| GWT compilation  |   4min  |  6min |
-| GWT scripts size  |  4.5 MB |   7.7 MB |
-| IDE WAR size  |   6.3MB |   8MB |      
 
 {% endif %}
 
@@ -487,10 +479,10 @@ There are two maven modules that you will need to consider:
 
 These two modules will be used to create either a standard assembly or a sample.
 
-### Standard IDE Assembly
+## Standard IDE Assembly
 To make a standard assembly of the IDE, we need to declare it in `assembly/compiling-ide-war/pom.xml`.
 
-1. Standard IDE core only
+**1) Standard IDE core only**
 
 ```
    <dependency>
@@ -499,7 +491,7 @@ To make a standard assembly of the IDE, we need to declare it in `assembly/compi
    </dependency>
 ```
 
-2.  All IDE plugins we have in Codenvy.
+**2)  All IDE plugins we have in Codenvy**
 
 ```
    <dependency>
@@ -508,7 +500,7 @@ To make a standard assembly of the IDE, we need to declare it in `assembly/compi
    </dependency>
 ```
 
-3.  All IDE plugins we have in Che.
+**3) All IDE plugins we have in Che**
 
 ```
    <dependency>
@@ -524,10 +516,10 @@ To make a standard assembly of the IDE, we need to declare it in `assembly/compi
    </dependency>
 ```
 
-### Minimal IDE Assembly
+## Minimal IDE Assembly
 To make a minimal assembly of the IDE, we need to declare it in `assembly/assembly-ide-war/pom.xml`.
 
-1. Codenvy IDE Core
+**1) Codenvy IDE Core**
 
 ```
    <dependency>
@@ -537,7 +529,7 @@ To make a minimal assembly of the IDE, we need to declare it in `assembly/assemb
    </dependency>
 ```
 
-2.  IDE Part of a Custom Plugin
+**2) IDE Part of a Custom Plugin**
 
 ```
    <dependency>
@@ -547,7 +539,7 @@ To make a minimal assembly of the IDE, we need to declare it in `assembly/assemb
    </dependency>
 ```
 
-3.  IDE WAR is Reused to Get Key Resources
+**3) IDE WAR is Reused to Get Key Resources**
 
 ```
    <dependency>
@@ -558,9 +550,9 @@ To make a minimal assembly of the IDE, we need to declare it in `assembly/assemb
    </dependency>
 ```
 
-### Standard Assembly of ws-agent Server WAR
+## Standard Assembly of ws-agent Server WAR
 
-1. Core ws-agent WAR
+**1) Core ws-agent WAR**
 
 ```
    <dependency>
@@ -570,7 +562,7 @@ To make a minimal assembly of the IDE, we need to declare it in `assembly/assemb
    </dependency>
 ```
 
-2.  Swagger Support
+**2) Swagger support**
 
 ```
    <dependency>
@@ -579,7 +571,7 @@ To make a minimal assembly of the IDE, we need to declare it in `assembly/assemb
    </dependency>
 ```
 
-3. All Codenvy ws-agent Plugins
+**3) All Codenvy ws-agent plugins**
 
 ```
    <dependency>
@@ -588,7 +580,7 @@ To make a minimal assembly of the IDE, we need to declare it in `assembly/assemb
    </dependency>
 ```
 
-4. All Che ws-agent Plugins
+**4) All Che ws-agent plugins**
 
 ```
    <dependency>
@@ -604,9 +596,9 @@ To make a minimal assembly of the IDE, we need to declare it in `assembly/assemb
    </dependency>
 ```
 
-### Custom Assembly of Minimal Codenvy ws-agent
+## Custom Assembly of Minimal Codenvy ws-agent
 
-1. Core Ws Agent WAR
+**1) Core Ws Agent WAR**
 
 ```
    <dependency>
@@ -616,7 +608,7 @@ To make a minimal assembly of the IDE, we need to declare it in `assembly/assemb
    </dependency>
 ```
 
-2. Server Side Plugin
+**2) Server Side Plugin**
 
 ```
    <dependency>


### PR DESCRIPTION
Documentation outlining how to build minimal (core only) and standard (core plus plugins) assemblies for Che. This is helpful for organizations that are extending Che and want a quick way to build a minimal Che that they can add plugins to.

Replaces https://github.com/eclipse/che-docs/pull/198

Signed-off-by: Brad Micklea <bmicklea@codenvy.com>