### PR TITLE
Clarified docs message

### DIFF
--- a/src/main/docs.sh
+++ b/src/main/docs.sh
@@ -40,7 +40,7 @@ elif [ "$BUILD_OR_RUN" = "--run" ]; then
 	COMMAND="jekyll serve -w --force_polling --incremental"	
 
   echo ""
-	echo "Connect to local server at http://localhost:9080"
+	echo "View generated docs at http://localhost:9080/docs/"
   echo ""
 fi
 


### PR DESCRIPTION
Reworded the `echo` to include the full path to the docs for users who generate docs locally.

Signed-off-by: Brad Micklea <bmicklea@codenvy.com>