### PR TITLE
Fixed typo in docs

### DIFF
--- a/src/main/_docs/assemblies/assemblies-assembly-lifecycle.md
+++ b/src/main/_docs/assemblies/assemblies-assembly-lifecycle.md
@@ -27,7 +27,7 @@ The CLI has an `archetype` command that can be used to generate custom assemblie
 
 An archetype is a maven technique for generating code templates. A single archetype has an ID and generates a complete custom assembly. Differnent archetypes generate assemblies with different types of customizations. We make each archetype customize the minimal number of features to make learning about customizations simpler.
 
-Your host system must have Maven 3.3+ installed to facilitate generation and compiling of custom assemblies. You must pass in your Maven's M2 repository path on your host. Our archetype generator will download libraries into that repository making repeated compilations faster over time. On most Linux based systems, your M2 repository is located at `/home/user/.m2/repository` and it is `%USERPROFILE%/.m2/repository` for Windows. We default your M2 repository to `/home/user/.m2/repository`. Use the `/m2` mount to chnage this.
+Your host system must have Maven 3.3+ installed to facilitate generation and compiling of custom assemblies. You must pass in your Maven's M2 repository path on your host. Our archetype generator will download libraries into that repository making repeated compilations faster over time. On most Linux based systems, your M2 repository is located at `/home/user/.m2/repository` and it is `%USERPROFILE%/.m2/repository` for Windows. We default your M2 repository to `/home/user/.m2/repository`. Use the `/m2` mount to change this.
 
 The syntax is:
 
@@ -118,7 +118,7 @@ The generator and templates for each assembly is in an [assembly generator repos
 | `agent-archetype` | Sample custom agent |
 | `plugin-menu-archetype` | IDE extension to customize the menu |
 | `plugin-wizard-archetype` | Custom C project type extension |
-| `plugin-serverservice-archetype` | Simple IDE extesion and a workspace service |
+| `plugin-serverservice-archetype` | Simple IDE extension and a workspace service |
 | `plugin-embedjs-archetype` | IDE extension with JavaScript in widgets |
 | `plugin-json-archetype` | JSON project type, codeassistant, and workspace service |
 

--- a/src/main/_docs/assemblies/assemblies-introduction.md
+++ b/src/main/_docs/assemblies/assemblies-introduction.md
@@ -17,7 +17,7 @@ Che is commonly extended in three ways: the browser IDE, the Che Server, or a wo
 3. A user's workspace can be extended to provide new APIs inside of agents to be used by the Che server or the browser IDE.
 ![image05.png]({{ base }}/docs/assets/imgs/image05.png)  
 
-We do not organize the documentation by component, but instead by types of customizations. You will oftne add a new capability to Che that requires server and client side extensions, so a single custom assembly may have multiple plugins that collectively are required for the distributed system to properly operate.
+We do not organize the documentation by component, but instead by types of customizations. You will often add a new capability to Che that requires server and client side extensions, so a single custom assembly may have multiple plugins that collectively are required for the distributed system to properly operate.
 
 Technically, client and server extensions are different components, however, they can be organized a single plugin with several sub-components.
 


### PR DESCRIPTION
Signed-off-by: Victor <victor.nea@gmail.com>

Fixed typo in docs:

- "oftne" instead of "often"
- "extesion" instead of "extension"
-  "chnage" instead of "change"

