### PR TITLE
New documentation page for installation and setup of Che on OpenShift

### DIFF
--- a/src/main/_data/docs.yml
+++ b/src/main/_data/docs.yml
@@ -19,6 +19,7 @@
   - setup-cli
   - setup-glossary
   - setup-docker
+  - setup-openshift
 - title: WORKSPACE ADMINISTRATION
   docs:
   - devops-intro

--- a/src/main/_docs/devops/devops-runtime-recipes.md
+++ b/src/main/_docs/devops/devops-runtime-recipes.md
@@ -47,7 +47,7 @@ Che base stacks, which include the minimum utilities for everything needed by Ec
 In `che-dockerfiles` repository, some recipes have sub-directories which represent tags. For example, the `/php/gae` directory in the GitHub repository would be pulled as `eclipse/php:gae` from Docker Hub.
 
 ### Inherit From Non-Eclipse Che Base Images
-This will create the best performing workspace image by only installing the minimum dependencies and packages required for your workspace. The trade off is that you have to include [Che's runtime dependencies]({{base}}{{site.links["devops-runtimev-recipes"]}}#che-runtime-required-dependencies) so we can work our magic in the workspace.
+This will create the best performing workspace image by only installing the minimum dependencies and packages required for your workspace. The trade off is that you have to include [Che's runtime dependencies]({{base}}{{site.links["devops-runtime-recipes"]}}#che-runtime-required-dependencies) so we can work our magic in the workspace.
 
 ### Che Runtime Required Dependencies
 

--- a/src/main/_docs/setup/setup-openshift.md
+++ b/src/main/_docs/setup/setup-openshift.md
@@ -11,6 +11,12 @@ You can run the Che server and its workspaces with OpenShift.
 OpenShift is built on top of Kubernetes and has built-in Docker registry, reverse proxy and OAuth server.
 OpenShift is ideal to deploy Che as enterprise wide cloud IDE.
 
+We currently support Che deployment for the following OpenShift flavours:
+
+- [OpenShift Container Platform](#deploy-che-on-openshift-container-platform)
+- [minishift](#deploy-che-on-minishift)
+- [openshift.io](#deploy-che-on-openshiftio) (for Che developers only)
+
 # Deploy Che on OpenShift Container Platform
 
 Use environment variables to set deployment options
@@ -48,7 +54,9 @@ curl -fsSL ${STACKS_SCRIPT_URL} -o stacks-che.sh
 bash get-che.sh && wait-che.sh && stacks-che.sh
 ```
 
-# Deploy Che on openshift.io (only for developers that want to test changes they are making to Che)
+# Deploy Che on openshift.io
+
+Please note that deploying Che on [openshift.io](openshift.io) is only intended for Che developers and osio contributors. This is useful when a developer wants to test how changes will work on [openshift.io](openshift.io) but is not supposed to work for every [openshift.io](openshift.io) user.
 
 Use environment variables to set deployment options
 

--- a/src/main/_docs/setup/setup-openshift.md
+++ b/src/main/_docs/setup/setup-openshift.md
@@ -7,19 +7,17 @@ permalink: /:categories/openshift/
 ---
 {% include base.html %}
 
-You can run the Che server and its workspaces with OpenShift.
-OpenShift is built on top of Kubernetes and has built-in Docker registry, reverse proxy and OAuth server.
-OpenShift is ideal to deploy Che as enterprise wide cloud IDE.
+You can run the Che server and its workspaces with [OpenShift](https://www.openshift.com/). OpenShift is built on top of Kubernetes and has a built-in Docker registry, reverse proxy and OAuth server. OpenShift can be used to deploy Che as enterprise-wide cloud IDE.
 
 We currently support Che deployment for the following OpenShift flavours:
 
 - [OpenShift Container Platform](#deploy-che-on-openshift-container-platform)
-- [minishift](#deploy-che-on-minishift)
-- [openshift.io](#deploy-che-on-openshiftio) (for Che developers only)
+- [Minishift](#deploy-che-on-minishift)
+- [Openshift.io](#deploy-che-on-openshiftio) (only for developing Che itself)
 
 # Deploy Che on OpenShift Container Platform
 
-Use environment variables to set deployment options
+Use environment variables to set [deployment options](#deployment-options):
 
 ```shell
 export OPENSHIFT_ENDPOINT=<OCP_ENDPOINT_URL> # e.g. https://opnshmdnsy3t7twsh.centralus.cloudapp.azure.com:8443
@@ -28,7 +26,7 @@ export OPENSHIFT_NAMESPACE_URL=<CHE_HOSTNAME> # e.g. che-eclipse-che.52.173.199.
 export OPENSHIFT_FLAVOR=ocp
 ```
 
-Download and run deployment scripts
+Download and run deployment scripts:
 
 ```shell
 DEPLOY_SCRIPT_URL=https://raw.githubusercontent.com/eclipse/che/master/dockerfiles/cli/scripts/openshift/deploy_che.sh
@@ -42,7 +40,7 @@ bash ./get-che.sh && bash ./wait-che.sh && bash ./stacks-che.sh
 
 # Deploy Che on Minishift
 
-Download and run deployment scripts
+Download and run deployment scripts:
 
 ```shell
 DEPLOY_SCRIPT_URL=https://raw.githubusercontent.com/eclipse/che/master/dockerfiles/cli/scripts/openshift/deploy_che.sh
@@ -56,16 +54,16 @@ bash ./get-che.sh && bash ./wait-che.sh && bash ./stacks-che.sh
 
 # Deploy Che on openshift.io
 
-Please note that deploying Che on [openshift.io](openshift.io) is only intended for Che developers and osio contributors. This is useful when a developer wants to test how changes will work on [openshift.io](openshift.io) but is not supposed to work for every [openshift.io](openshift.io) user.
+Please note that deploying Che on [OpenShift.io](openshift.io) (OSIO) is only intended for Che developers and OSIO contributors. This is useful when a developer wants to test how changes will work on [OpenShift.io](openshift.io). If you are interested in using OpenShift.io you can [sign up](https://openshift.io/) for the service.
 
-Use environment variables to set deployment options
+Use environment variables to set [deployment options](#deployment-options):
 
 ```shell
 export OPENSHIFT_TOKEN=<OSO_TOKEN> # Retrieve the OSO_TOKEN from https://console.starter-us-east-2.openshift.com/console/command-line
 export OPENSHIFT_FLAVOR=osio
 ```
 
-Download and run deployment scripts
+Download and run deployment scripts:
 
 ```shell
 DEPLOY_SCRIPT_URL=https://raw.githubusercontent.com/eclipse/che/master/dockerfiles/cli/scripts/openshift/deploy_che.sh
@@ -81,10 +79,10 @@ bash ./get-che.sh && bash ./wait-che.sh && bash ./stacks-che.sh
 
 You can set different deployment options using environment variables:
 
-* `OPENSHIFT_FLAVOR`: possible values are `ocp`, `minishift` and `osio` (default is `minishift`)
-* `OPENSHIFT_ENDPOINT`: url of the OpenShift API (default is unset for ocp, `https://$(minishift ip):8443/` for minishift, `https://api.starter-us-east-2.openshift.com` for osio)
+* `OPENSHIFT_FLAVOR`: Possible values are `ocp`, `minishift` and `osio` (default is `minishift`)
+* `OPENSHIFT_ENDPOINT`: URL of the OpenShift API (default is unset for ocp, `https://$(minishift ip):8443/` for minishift, `https://api.starter-us-east-2.openshift.com` for osio)
 * `OPENSHIFT_TOKEN` (default is unset)
-* `CHE_OPENSHIFT_PROJECT`: the OpenShift namespace where Che will be deployed (default is `eclipse-che` for ocp and minishift and `${OPENSHIFT_ID}-che` for osio)
+* `CHE_OPENSHIFT_PROJECT`: The OpenShift namespace where Che will be deployed (default is `eclipse-che` for ocp and minishift and `${OPENSHIFT_ID}-che` for osio)
 * `CHE_IMAGE_REPO`: `che-server` Docker image repository that will be used for deployment (default is `docker.io/eclipse/che-server`)
 * `CHE_IMAGE_TAG`: `che-server` Docker image tag that will be used for deployment (default is `nightly-centos`)
 * `CHE_LOG_LEVEL`: Logging level of output for Che server. Can be `debug` or `info` (default is `DEBUG`)
@@ -92,7 +90,7 @@ You can set different deployment options using environment variables:
 * `CHE_KEYCLOAK_DISABLED`: If this is set to true Keycloack authentication will be disabled (default is `true` for ocp and minishift, `false` for osio)
 * `OPENSHIFT_NAMESPACE_URL`: The Che application hostname (default is unset for ocp, `${CHE_OPENSHIFT_PROJECT}.$(minishift ip).nip.io` for minishift, `${CHE_OPENSHIFT_PROJECT}.8a09.starter-us-east-2.openshiftapps.com` for osio)
 
-These are OCP and minishift only options:
+OCP and Minishift only options:
 
 * `OPENSHIFT_USERNAME`: username to login on the OpenShift cluster. Ignored if `OPENSHIFT_TOKEN` is set (default is `developer`)
 * `OPENSHIFT_PASSWORD`: password to login on the OpenShift cluster. Ignored if `OPENSHIFT_TOKEN` is set (default is `developer`)
@@ -101,7 +99,8 @@ These are OCP and minishift only options:
 
 Defining a custom Runtime Stack using [a recipe]({{base}}{{site.links["devops-runtime-recipes"]}}), as a Dockerfile or a Docker Compose file, is currently not supported on OpenShift.
 
-However it is still possible to define new Runtime Stacks using already built Docker images that have been pushed to a Docker registry. Instructions to create a custom Runtime Stack can be found [here]({{base}}{{site.links["devops-runtime-stacks"]}}).
+However it is still possible to define new Runtime Stacks using Docker images that have been pushed to a Docker registry. Instructions to create a custom Runtime Stack can be found [here]({{base}}{{site.links["devops-runtime-stacks"]}}).
 
-When using a custom Docker image that image must meet [the normal criteria]({{base}}{{site.links["devops-runtime-recipes"]}}#che-runtime-required-dependencies) required to run as a Che runtime. In addition it should follow the [guidelines to create Docker images to run on OpenShift](https://docs.openshift.org/latest/creating_images/guidelines.html#openshift-origin-specific-guidelines).
+Custom Docker images must meet [the normal criteria]({{base}}{{site.links["devops-runtime-recipes"]}}#che-runtime-required-dependencies) required to run as a Che runtime. In addition it should follow the [guidelines to create Docker images to run on OpenShift](https://docs.openshift.org/latest/creating_images/guidelines.html#openshift-origin-specific-guidelines).
+
 Some examples of Dockerfiles used to create such images can be found [here](https://github.com/redhat-developer/che-dockerfiles/tree/master/recipes).

--- a/src/main/_docs/setup/setup-openshift.md
+++ b/src/main/_docs/setup/setup-openshift.md
@@ -48,7 +48,7 @@ curl -fsSL ${STACKS_SCRIPT_URL} -o stacks-che.sh
 bash get-che.sh && wait-che.sh && stacks-che.sh
 ```
 
-# Deploy Che on openshift.io  (only for developers that want to test changes they are making to Che)
+# Deploy Che on openshift.io (only for developers that want to test changes they are making to Che)
 
 Use environment variables to set deployment options
 

--- a/src/main/_docs/setup/setup-openshift.md
+++ b/src/main/_docs/setup/setup-openshift.md
@@ -79,7 +79,7 @@ You can set different deployment options using environment variables:
 * `CHE_OPENSHIFT_PROJECT`: the OpenShift namespace where Che will be deployed (default is `eclipse-che` for ocp and minishift and `${OPENSHIFT_ID}-che` for osio)
 * `CHE_IMAGE_REPO`: `che-server` Docker image repository that will be used for deployment (default is `docker.io/eclipse/che-server`)
 * `CHE_IMAGE_TAG`: `che-server` Docker image tag that will be used for deployment (default is `nightly-centos`)
-* `CHE_LOG_LEVEL`: Log level of che-server (default is `DEBUG`)
+* `CHE_LOG_LEVEL`: Logging level of output for Che server. Can be `debug` or `info` (default is `DEBUG`)
 * `CHE_DEBUGGING_ENABLED`: If set to `true` the script will create the OpenShift service to debug che-server (default is `true`)
 * `CHE_KEYCLOAK_DISABLED`: If this is set to true Keycloack authentication will be disabled (default is `true` for ocp and minishift, `false` for osio)
 * `OPENSHIFT_NAMESPACE_URL`: The Che application hostname (default is unset for ocp, `${CHE_OPENSHIFT_PROJECT}.$(minishift ip).nip.io` for minishift, `${CHE_OPENSHIFT_PROJECT}.8a09.starter-us-east-2.openshiftapps.com` for osio)

--- a/src/main/_docs/setup/setup-openshift.md
+++ b/src/main/_docs/setup/setup-openshift.md
@@ -48,7 +48,7 @@ curl -fsSL ${STACKS_SCRIPT_URL} -o stacks-che.sh
 bash get-che.sh && wait-che.sh && stacks-che.sh
 ```
 
-# Deploy Che on openshift.io
+# Deploy Che on openshift.io  (only for developers that want to test changes they are making to Che)
 
 Use environment variables to set deployment options
 

--- a/src/main/_docs/setup/setup-openshift.md
+++ b/src/main/_docs/setup/setup-openshift.md
@@ -95,5 +95,5 @@ Defining a custom Runtime Stack using [a recipe]({{base}}{{site.links["devops-ru
 
 However it is still possible to define new Runtime Stacks using already built Docker images that have been pushed to a Docker registry. Instructions to create a custom Runtime Stack can be found [here]({{base}}{{site.links["devops-runtime-stacks"]}}).
 
-When using a custom Docker image that image must meet [the normal criteria]({{base}}{{site.links["devops-runtime-recipes"]}}#che-runtime-required-dependencies) required to run as a Che runtime. In addition it should follow the [guidelines to creat Docker images to run on OpenShift](https://docs.openshift.org/latest/creating_images/guidelines.html#openshift-origin-specific-guidelines).
+When using a custom Docker image that image must meet [the normal criteria]({{base}}{{site.links["devops-runtime-recipes"]}}#che-runtime-required-dependencies) required to run as a Che runtime. In addition it should follow the [guidelines to create Docker images to run on OpenShift](https://docs.openshift.org/latest/creating_images/guidelines.html#openshift-origin-specific-guidelines).
 Some examples of Dockerfiles used to create such images can be found [here](https://github.com/redhat-developer/che-dockerfiles/tree/master/recipes).

--- a/src/main/_docs/setup/setup-openshift.md
+++ b/src/main/_docs/setup/setup-openshift.md
@@ -34,10 +34,10 @@ Download and run deployment scripts
 DEPLOY_SCRIPT_URL=https://raw.githubusercontent.com/eclipse/che/master/dockerfiles/cli/scripts/openshift/deploy_che.sh
 WAIT_SCRIPT_URL=https://raw.githubusercontent.com/eclipse/che/master/dockerfiles/cli/scripts/openshift/wait_until_che_is_available.sh
 STACKS_SCRIPT_URL=https://raw.githubusercontent.com/eclipse/che/master/dockerfiles/cli/scripts/openshift/replace_stacks.sh
-curl -fsSL ${DEPLOY_SCRIPT_URL} -o get-che.sh
-curl -fsSL ${WAIT_SCRIPT_URL} -o wait-che.sh
-curl -fsSL ${STACKS_SCRIPT_URL} -o stacks-che.sh
-bash get-che.sh && wait-che.sh && stacks-che.sh
+curl -fsSL ${DEPLOY_SCRIPT_URL} -o ./get-che.sh
+curl -fsSL ${WAIT_SCRIPT_URL} -o ./wait-che.sh
+curl -fsSL ${STACKS_SCRIPT_URL} -o ./stacks-che.sh
+bash ./get-che.sh && bash ./wait-che.sh && bash ./stacks-che.sh
 ```
 
 # Deploy Che on Minishift
@@ -48,10 +48,10 @@ Download and run deployment scripts
 DEPLOY_SCRIPT_URL=https://raw.githubusercontent.com/eclipse/che/master/dockerfiles/cli/scripts/openshift/deploy_che.sh
 WAIT_SCRIPT_URL=https://raw.githubusercontent.com/eclipse/che/master/dockerfiles/cli/scripts/openshift/wait_until_che_is_available.sh
 STACKS_SCRIPT_URL=https://raw.githubusercontent.com/eclipse/che/master/dockerfiles/cli/scripts/openshift/replace_stacks.sh
-curl -fsSL ${DEPLOY_SCRIPT_URL} -o get-che.sh
-curl -fsSL ${WAIT_SCRIPT_URL} -o wait-che.sh
-curl -fsSL ${STACKS_SCRIPT_URL} -o stacks-che.sh
-bash get-che.sh && wait-che.sh && stacks-che.sh
+curl -fsSL ${DEPLOY_SCRIPT_URL} -o ./get-che.sh
+curl -fsSL ${WAIT_SCRIPT_URL} -o ./wait-che.sh
+curl -fsSL ${STACKS_SCRIPT_URL} -o ./stacks-che.sh
+bash ./get-che.sh && bash ./wait-che.sh && bash ./stacks-che.sh
 ```
 
 # Deploy Che on openshift.io
@@ -71,10 +71,10 @@ Download and run deployment scripts
 DEPLOY_SCRIPT_URL=https://raw.githubusercontent.com/eclipse/che/master/dockerfiles/cli/scripts/openshift/deploy_che.sh
 WAIT_SCRIPT_URL=https://raw.githubusercontent.com/eclipse/che/master/dockerfiles/cli/scripts/openshift/wait_until_che_is_available.sh
 STACKS_SCRIPT_URL=https://raw.githubusercontent.com/eclipse/che/master/dockerfiles/cli/scripts/openshift/replace_stacks.sh
-curl -fsSL ${DEPLOY_SCRIPT_URL} -o get-che.sh
-curl -fsSL ${WAIT_SCRIPT_URL} -o wait-che.sh
-curl -fsSL ${STACKS_SCRIPT_URL} -o stacks-che.sh
-bash get-che.sh && wait-che.sh && stacks-che.sh
+curl -fsSL ${DEPLOY_SCRIPT_URL} -o ./get-che.sh
+curl -fsSL ${WAIT_SCRIPT_URL} -o ./wait-che.sh
+curl -fsSL ${STACKS_SCRIPT_URL} -o ./stacks-che.sh
+bash ./get-che.sh && bash ./wait-che.sh && bash ./stacks-che.sh
 ```
 
 # Deployment Options

--- a/src/main/_docs/setup/setup-openshift.md
+++ b/src/main/_docs/setup/setup-openshift.md
@@ -1,0 +1,99 @@
+---
+tags: [ "eclipse" , "che" ]
+title: OpenShift Installation
+excerpt: "Run Che on OpenShift."
+layout: docs
+permalink: /:categories/openshift/
+---
+{% include base.html %}
+
+You can run the Che server and its workspaces with OpenShift.
+OpenShift is built on top of Kubernetes and has built-in Docker registry, reverse proxy and OAuth server.
+OpenShift is ideal to deploy Che as enterprise wide cloud IDE.
+
+# Deploy Che on OpenShift Container Platform
+
+Use environment variables to set deployment options
+
+```shell
+export OPENSHIFT_ENDPOINT=<OCP_ENDPOINT_URL> # e.g. https://opnshmdnsy3t7twsh.centralus.cloudapp.azure.com:8443
+export OPENSHIFT_TOKEN=<OCP_TOKEN>
+export OPENSHIFT_NAMESPACE_URL=<CHE_HOSTNAME> # e.g. che-eclipse-che.52.173.199.80.xip.io
+export OPENSHIFT_FLAVOR=ocp
+```
+
+Download and run deployment scripts
+
+```shell
+DEPLOY_SCRIPT_URL=https://raw.githubusercontent.com/eclipse/che/master/dockerfiles/cli/scripts/openshift/deploy_che.sh
+WAIT_SCRIPT_URL=https://raw.githubusercontent.com/eclipse/che/master/dockerfiles/cli/scripts/openshift/wait_until_che_is_available.sh
+STACKS_SCRIPT_URL=https://raw.githubusercontent.com/eclipse/che/master/dockerfiles/cli/scripts/openshift/replace_stacks.sh
+curl -fsSL ${DEPLOY_SCRIPT_URL} -o get-che.sh
+curl -fsSL ${WAIT_SCRIPT_URL} -o wait-che.sh
+curl -fsSL ${STACKS_SCRIPT_URL} -o stacks-che.sh
+bash get-che.sh && wait-che.sh && stacks-che.sh
+```
+
+# Deploy Che on Minishift
+
+Download and run deployment scripts
+
+```shell
+DEPLOY_SCRIPT_URL=https://raw.githubusercontent.com/eclipse/che/master/dockerfiles/cli/scripts/openshift/deploy_che.sh
+WAIT_SCRIPT_URL=https://raw.githubusercontent.com/eclipse/che/master/dockerfiles/cli/scripts/openshift/wait_until_che_is_available.sh
+STACKS_SCRIPT_URL=https://raw.githubusercontent.com/eclipse/che/master/dockerfiles/cli/scripts/openshift/replace_stacks.sh
+curl -fsSL ${DEPLOY_SCRIPT_URL} -o get-che.sh
+curl -fsSL ${WAIT_SCRIPT_URL} -o wait-che.sh
+curl -fsSL ${STACKS_SCRIPT_URL} -o stacks-che.sh
+bash get-che.sh && wait-che.sh && stacks-che.sh
+```
+
+# Deploy Che on openshift.io
+
+Use environment variables to set deployment options
+
+```shell
+export OPENSHIFT_TOKEN=<OSO_TOKEN> # Retrieve the OSO_TOKEN from https://console.starter-us-east-2.openshift.com/console/command-line
+export OPENSHIFT_FLAVOR=osio
+```
+
+Download and run deployment scripts
+
+```shell
+DEPLOY_SCRIPT_URL=https://raw.githubusercontent.com/eclipse/che/master/dockerfiles/cli/scripts/openshift/deploy_che.sh
+WAIT_SCRIPT_URL=https://raw.githubusercontent.com/eclipse/che/master/dockerfiles/cli/scripts/openshift/wait_until_che_is_available.sh
+STACKS_SCRIPT_URL=https://raw.githubusercontent.com/eclipse/che/master/dockerfiles/cli/scripts/openshift/replace_stacks.sh
+curl -fsSL ${DEPLOY_SCRIPT_URL} -o get-che.sh
+curl -fsSL ${WAIT_SCRIPT_URL} -o wait-che.sh
+curl -fsSL ${STACKS_SCRIPT_URL} -o stacks-che.sh
+bash get-che.sh && wait-che.sh && stacks-che.sh
+```
+
+# Deployment Options
+
+You can set different deployment options using environment variables:
+
+* `OPENSHIFT_FLAVOR`: possible values are `ocp`, `minishift` and `osio` (default is `minishift`)
+* `OPENSHIFT_ENDPOINT`: url of the OpenShift API (default is unset for ocp, `https://$(minishift ip):8443/` for minishift, `https://api.starter-us-east-2.openshift.com` for osio)
+* `OPENSHIFT_TOKEN` (default is unset)
+* `CHE_OPENSHIFT_PROJECT`: the OpenShift namespace where Che will be deployed (default is `eclipse-che` for ocp and minishift and `${OPENSHIFT_ID}-che` for osio)
+* `CHE_IMAGE_REPO`: `che-server` Docker image repository that will be used for deployment (default is `docker.io/eclipse/che-server`)
+* `CHE_IMAGE_TAG`: `che-server` Docker image tag that will be used for deployment (default is `nightly-centos`)
+* `CHE_LOG_LEVEL`: Log level of che-server (default is `DEBUG`)
+* `CHE_DEBUGGING_ENABLED`: If set to `true` the script will create the OpenShift service to debug che-server (default is `true`)
+* `CHE_KEYCLOAK_DISABLED`: If this is set to true Keycloack authentication will be disabled (default is `true` for ocp and minishift, `false` for osio)
+* `OPENSHIFT_NAMESPACE_URL`: The Che application hostname (default is unset for ocp, `${CHE_OPENSHIFT_PROJECT}.$(minishift ip).nip.io` for minishift, `${CHE_OPENSHIFT_PROJECT}.8a09.starter-us-east-2.openshiftapps.com` for osio)
+
+These are OCP and minishift only options:
+
+* `OPENSHIFT_USERNAME`: username to login on the OpenShift cluster. Ignored if `OPENSHIFT_TOKEN` is set (default is `developer`)
+* `OPENSHIFT_PASSWORD`: password to login on the OpenShift cluster. Ignored if `OPENSHIFT_TOKEN` is set (default is `developer`)
+
+# Custom Che Workspace Runtimes in OpenShift
+
+Defining a custom Runtime Stack using [a recipe]({{base}}{{site.links["devops-runtime-recipes"]}}), as a Dockerfile or a Docker Compose file, is currently not supported on OpenShift.
+
+However it is still possible to define new Runtime Stacks using already built Docker images that have been pushed to a Docker registry. Instructions to create a custom Runtime Stack can be found [here]({{base}}{{site.links["devops-runtime-stacks"]}}).
+
+When using a custom Docker image that image must meet [the normal criteria]({{base}}{{site.links["devops-runtime-recipes"]}}#che-runtime-required-dependencies) required to run as a Che runtime. In addition it should follow the [guidelines to creat Docker images to run on OpenShift](https://docs.openshift.org/latest/creating_images/guidelines.html#openshift-origin-specific-guidelines).
+Some examples of Dockerfiles used to create such images can be found [here](https://github.com/redhat-developer/che-dockerfiles/tree/master/recipes).


### PR DESCRIPTION
New documentation page with the instructions to deploy Che on different OpenShift flavours:

- OpenShift Container Platform
- minishift
- OpenShift.io