### PR TITLE
Update selenium tests doc

### DIFF
--- a/src/main/_docs/setup/setup-selenium.md
+++ b/src/main/_docs/setup/setup-selenium.md
@@ -9,17 +9,17 @@ permalink: /:categories/selenium/
 
 Eclipse Che is providing a set of automated tests. This documentation explain how to configure your system in order to be able to the Selenium tests suite.
 
-You can find the Selenium tests suite [here: https://github.com/eclipse/che/tree/master/selenium](https://github.com/eclipse/che/tree/master/selenium)
+You can find the Selenium tests suite [here: https://github.com/eclipse/che/tree/che6/selenium](https://github.com/eclipse/che/tree/che6/selenium)
 
 #### 1. Register OAuth application
 
 Go to [OAuth application page](https://github.com/settings/applications/new) and register a new application:
 * `Application name` : `Che`
-* `Homepage URL` : `http://<YOUR_IP_ADDRESS>:8080`
+* `Homepage URL` : `http://<YOUR_IP_ADDRESS><:YOUR_CHE_PORT>`
 * `Application description` : `Che`
-* `Authorization callback URL` : `http://<YOUR_IP_ADDRESS>:8080/api/oauth/callback`
+* `Authorization callback URL` : `http://<YOUR_IP_ADDRESS><:YOUR_CHE_PORT>/api/oauth/callback`
 
-Substitute `CHE_OAUTH_GITHUB_CLIENTID` and `CHE_OAUTH_GITHUB_CLIENTSECRET` properties in `che.env` with `Client ID` and `Client Secret` taken from
+Substitute `CHE_OAUTH_GITHUB_CLIENTID` and `CHE_OAUTH_GITHUB_CLIENTSECRET` properties in `che.env` with `Client ID` and `Client Secret` taken from 
 newly created [OAuth application](https://github.com/settings/developers).
 
 #### 2. Add configuration file
@@ -27,6 +27,13 @@ newly created [OAuth application](https://github.com/settings/developers).
 Set `CHE_LOCAL_CONF_DIR` environment variable and point to the folder where selenium tests configuration will be stored.
 Create file `selenium.properties` in that folder with the following content:
 ```
+# Credentials of Eclipse Che multiuser assemblies
+che.admin_user.email=<CHE_ADMIN_EMAIL>
+che.admin_user.password=<CHE_ADMIN_PASSWORD>
+
+che.test_user.email=<CHE_USER_EMAIL>
+che.test_user.password=<CHE_USER_PASSWORD>
+
 # GitHub account credentials
 github.username=<MAIN_GITHUB_USERNAME>
 github.password=<MAIN_GITHUB_PASSWORD>
@@ -38,7 +45,7 @@ google.user=<GOOGLE_USER>
 google.password=<GOOGLE_PASSWORD>
 ```
 
-#### 3. Prepare repository
+#### 3. Prepare repository 
 Fork all repositories from [https://github.com/idexmai?tab=repositories](https://github.com/idexmai?tab=repositories) into the main GitHub account.
 Fork the repository [https://github.com/iedexmain1/pull-request-plugin-fork-test](https://github.com/iedexmain1/pull-request-plugin-fork-test) into the auxiliary GitHub account.
 
@@ -50,6 +57,20 @@ Follow the guide: [https://github.com/eclipse/che](https://github.com/eclipse/ch
 
 Simply launch `./selenium-tests.sh`
 
+### How to run tests on OpenShift
+#### Che in container case
+##### 1. Set workspace runtime infrastructure implementation
+export CHE_SELENIUM_INFRASTRUCTURE=openshift
+##### 2. Run tests in the default way
+Simply launch `./selenium-tests.sh`
+#### Che inside of OpenShift case
+##### 1. Set workspace runtime infrastructure implementation
+export CHE_SELENIUM_INFRASTRUCTURE=openshift
+##### 2. Run tests and specify host and port of Che deployed to OpenShift
+Launch `./selenium-tests.sh --host=<Che host on openshift> --port=80`
+
+Example: `./selenium-tests.sh --host=che-spi.192.168.99.100.nip.io --port=80`
+
 Run tests configuration properties
 --------------------------------------
 ```
@@ -59,9 +80,11 @@ Options:
     --http                              Use 'http' protocol to connect to product
     --https                             Use 'https' protocol to connect to product
     --host=<PRODUCT_HOST>               Set host where product is deployed
+    --port=<PRODUCT_PORT>               Set port of the product, default is 8080
+    --multiuser                         Run tests of Multi User Che
 
 Modes (defines environment to run tests):
-    local                               All tests will be run in a Web browser on the developer machine.
+    -Mlocal                             All tests will be run in a Web browser on the developer machine.
                                         Recommended if test visualization is needed and for debugging purpose.
 
         Options that go with 'local' mode:
@@ -71,8 +94,7 @@ Modes (defines environment to run tests):
                                         Web browsers will be opened on the developer machine.
                                         Default value is in range [2,5] and depends on available RAM.
 
-
-    grid (default)                      All tests will be run in parallel among several docker containers.
+    -Mgrid (default)                    All tests will be run in parallel among several docker containers.
                                         One container per thread. Recommended to run test suite.
 
         Options that go with 'grid' mode:
@@ -80,7 +102,6 @@ Modes (defines environment to run tests):
                                         Default value is in range [2,5] and depends on available RAM.
 
 Define tests scope:
-    --all-tests                         Run all tests within the suite despite of <exclude>/<include> sections in the test suite.
     --test=<TEST_CLASS>                 Single test to run
     --suite=<SUITE>                     Test suite to run, found:
                                             * CheSuite.xml
@@ -93,13 +114,19 @@ Handle failing tests:
 
 Other options:
     --debug                             Run tests in debug mode
+    --skip-sources-validation           Fast build. Skips source validation and enforce plugins
+    --workspace-pool-size=[<SIZE>|auto] Size of test workspace pool.
+                                        Default value is 0, that means that test workspaces are created on demand.
 
 HOW TO of usage:
-    Test Eclipse Che assembly:
-        ./selenium-tests.sh -Mgrid
+    Test Eclipse Che single user assembly:
+        ./selenium-tests.sh
+
+    Test Eclipse Che multi user assembly:
+        ./selenium-tests.sh --multiuser
 
     Test Eclipse Che assembly and automatically rerun failing tests:
-        ./selenium-tests.sh -Mgrid --rerun
+        ./selenium-tests.sh --rerun
 
     Run single test or package of tests:
         ./selenium-tests.sh <...> --test=<TEST>


### PR DESCRIPTION
This request renews selenium tests documentation: 
- adds **--multiuser**, **--skip-sources-validation**, **--workspace-pool-size**, **--port** parameters
- removes **--all-tests** parameter
- adds properties to define che admin/user credentials
- adds information about how to run tests on OpenShift.